### PR TITLE
Nippy serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ and the only Redis session store available ([rrss][rrss]) ... didn't.
 Important Changes
 -----------------
 
+* **3.3.0-SNAPSHOT**
+  - Data serialization now happens with default for
+    `com.taoensso/carmine` `nippy` library because original
+    serialization method was based on deprecated `eval` read macro `#=`;
+
+  - `read-handler` and `:write-handler` options added to constructor
+    which can be used to define custom data serialization format. See example in
+    [Customize data serialization format](#customize-data-serialization-format) section.
+
+
 * **v3.1.0** - This release has changed the repo name, project name, and release
   name from `clj-redis-session` to `ring-redis-session` (thanks @plexus for the
   great suggestion!)
@@ -118,20 +128,13 @@ something else:
 (wrap-session your-app {:store (redis-store conn {:prefix "your-app-prefix"})})
 ```
 
-Difference from `clojusc/ring-redis-session`
---------------------------------------------
+## Customize data serialization format
 
-* By default, data serialization now happen with default for
-  `com.taoensso/carmine` `nippy` lib because original serialization
-  method was based on `eval` read macro `#=` which is deprecated at
-  the moment and trashed out from clojurescript.
+The format of how data will be kept in Redis storage could be defined
+with `:read-handler`, `:write-handler` functions passed to
+constructor.
 
-* Added `read-handler`, `:write-handler` options to constructor option
-  so it is possible to change store format. For example, in my system
-  I have two different servers, `nodejs` based server for server-side
-  rendering and clojure `ring` server for API. I have to share session
-  somehow between them. I decided to use transit, so on API side I
-  configure session redis store like this:
+This example shows how to set handlers to store data in `transit` format:
 
 ```clojure
   (defn to-str [obj]
@@ -159,8 +162,6 @@ License
 Copyright © 2013 Zhe Wu <wu@madk.org>
 
 Copyright © 2016-2017 Clojure-Aided Enrichment Center
-
-Copyright © 2018 Anatoly Smolyaninov <zarkone@ya.ru>
 
 Distributed under the Eclipse Public License, the same as Clojure.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Installation
 
 Add
 ```clojure
-[clojusc/ring-redis-session "3.2.0"]
+[clojusc/ring-redis-session "3.3.0-SNAPSHOT"]
 ```
 to `:dependencies` in your `project.clj`.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojusc/ring-redis-session "3.2.0"
+(defproject clojusc/ring-redis-session "3.3.0-SNAPSHOT"
   :url "https://github.com/clojusc/ring-redis-session"
   :description "Redis-backed Clojure/Ring session store"
   :license
@@ -43,7 +43,7 @@
         [org.clojure/clojure "1.8.0"]]}
     :1.9 {
       :dependencies [
-        [org.clojure/clojure "1.9.0-alpha14"]]}
+        [org.clojure/clojure "1.9.0"]]}
     :docs {
       :exclusions [org.clojure/clojure]
       :dependencies [

--- a/src/ring/redis/session.clj
+++ b/src/ring/redis/session.clj
@@ -17,25 +17,23 @@
       (log/debug "In read-session ...")
       (log/debug "\tsession-key:" session-key)
       (when-let [data (redis/wcar conn (redis/get session-key))]
-        (if (and (:expiration this) (:reset-on-read this))
+        (when (and (:expiration this) (:reset-on-read this))
           (redis/wcar conn (redis/expire session-key (:expiration this))))
-        (read-string data)))))
+        data))))
 
 (defn write-redis-session
   "Write a session to a Redis store."
   [this old-session-key data]
   (let [conn (:redis-conn this)
         session-key (or old-session-key (util/new-session-key (:prefix this)))
-        data-str (binding [*print-dup* true]
-                   (print-str data))
         expiri (:expiration this)]
     (log/debug "In write-redis-session ...")
     (log/debug "\tsession-key:" session-key)
     (log/debug "\tdata:" (util/log-pprint data))
-    (log/debug "\tdata-str:" data-str)
+    (log/debug "\tdata-str:" data)
     (if expiri
-      (redis/wcar conn (redis/setex session-key expiri data-str))
-      (redis/wcar conn (redis/set session-key data-str)))
+      (redis/wcar conn (redis/setex session-key expiri data))
+      (redis/wcar conn (redis/set session-key data)))
     session-key))
 
 (defn delete-redis-session

--- a/src/ring/redis/session.clj
+++ b/src/ring/redis/session.clj
@@ -31,7 +31,6 @@
     (log/debug "In write-redis-session ...")
     (log/debug "\tsession-key:" session-key)
     (log/debug "\tdata:" (util/log-pprint data))
-    (log/debug "\tdata-str:" data)
     (let [write-handler (:write-handler this)]
       (if expiri
         (redis/wcar conn (redis/setex session-key expiri (write-handler data)))


### PR DESCRIPTION
Hi! 

Thanks for the library!

I have clojure API (with `ring` http server) and `cljs/nodejs` (with built-in nodejs http server) `react` server-side rendering app. I want to share session between them, but found a problem: seems like `#=` reader macro symbol support was removed from clojurescript and it will require a little bit more efforts to read/write sessions on cljs/nodejs side.

Wonder why `#=` used instead of built-in into `com.taoensso/carmine`  `nippy` library -- would be glad to learn. 
